### PR TITLE
Added wait_timeout to get the required state of the VM.

### DIFF
--- a/tests/playbooks/kubevirt_dv_vm.yaml
+++ b/tests/playbooks/kubevirt_dv_vm.yaml
@@ -14,6 +14,8 @@
     - name: Create a Cirros VM from a DataVolume
       kubevirt_vm:
         state: running
+        wait: true
+        wait_timeout: 200
         name: cirros-dv
         labels:
           special: test-e2e-key


### PR DESCRIPTION
Signed-off-by: Satyajit Bulage <sbulage@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
